### PR TITLE
remove deprecated argument names

### DIFF
--- a/R/leaf-par.R
+++ b/R/leaf-par.R
@@ -44,7 +44,7 @@ check_for_legacy_gunit = function(pars) {
   
   xx = pars |>
     purrr::map(units) |>
-    purrr::map_lgl(units::ud_are_convertible, y = "umol / m^2 / s / Pa") |>
+    purrr::map_lgl(units::ud_are_convertible, "umol / m^2 / s / Pa") |>
     any()
   
     if (xx) {


### PR DESCRIPTION
In the next release of `units`, arguments `x` andn `y` in `ud_are_convertible()` are deprecated, and renamed as `from` and `to`. `x` and `y` were unfortunate names. This fix simply removes the old name, so that this works regardless of the `units` version. But there is no rush to push an update to CRAN, because we still support `x` and `y` with a warning